### PR TITLE
Preserve byte size when encoding.

### DIFF
--- a/lib/crockford_base32.ex
+++ b/lib/crockford_base32.ex
@@ -205,7 +205,9 @@ defmodule CrockfordBase32 do
     do_encode_bytes_maybe_padding(value, expected_size, checksum)
   end
 
-  defp do_encode_bytes_maybe_padding(0, _, []), do: "0"
+  defp do_encode_bytes_maybe_padding(0, expected_size, []),
+    do: String.duplicate("0", expected_size)
+
   defp do_encode_bytes_maybe_padding(0, 0, acc), do: to_string(acc)
 
   defp do_encode_bytes_maybe_padding(0, size, acc) when size > 0 do

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule CrockfordBase32.MixProject do
   def project do
     [
       app: :crockford_base32,
-      version: "0.3.0",
+      version: "0.4.0",
       elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/crockford_base32_encode_test.exs
+++ b/test/crockford_base32_encode_test.exs
@@ -77,5 +77,13 @@ defmodule CrockfordBase32EncodeTest do
     assert CrockfordBase32.encode(bytes) == "05ZSQZWDJ0"
     bytes = <<1, 2, 3>>
     assert CrockfordBase32.encode(bytes) == "04106"
+    bytes = <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>
+    assert CrockfordBase32.encode(bytes) == "00000000000000000000000000"
+    bytes = <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>
+    assert CrockfordBase32.encode(bytes, checksum: true) == "000000000000000000000000000"
+    bytes = <<8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>
+    assert CrockfordBase32.encode(bytes) == "10000000000000000000000000"
+    bytes = <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1>>
+    assert CrockfordBase32.encode(bytes) == "00000000000000000000000004"
   end
 end


### PR DESCRIPTION
I am working on porting [Typeid](https://github.com/jetpack-io/typeid) to Elixir and found that when passing a zero byte array to encode I was getting a single 0 as a result when I was expecting the size to be preserved.

When passing `checksum: true` I was getting the complete size plus the checksum digit.

This adjusts that behaviour by preserving the size when encoding.